### PR TITLE
Add versioning to transport bindings

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -46,7 +46,7 @@ func New(serviceName string, options ...Option) (*Client, error) {
 
 	// Create middleware instances using the global middleware factories
 	for _, factory := range globalMiddlewareFactories {
-		c.middleware = append(c.middleware, factory())
+		c.middleware = append(c.middleware, factory(serviceName))
 	}
 
 	// Apply options

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -30,7 +30,7 @@ func TestClientRequest(t *testing.T) {
 	expGreeting := "hello tester"
 	expReqPayload := `{"name":"tester"}`
 	expResPayload := `{"greeting":"` + expGreeting + `"}`
-	tr.Bind("service", "endpoint", transport.HandlerFunc(
+	tr.Bind("", "service", "endpoint", transport.HandlerFunc(
 		func(req transport.ImmutableMessage, res transport.Message) {
 			payload, _ := req.Payload()
 			payloadStr := string(payload)
@@ -91,7 +91,7 @@ func TestClientRequestWithServerEndpointCtx(t *testing.T) {
 	expGreeting := "hello tester"
 	expReqPayload := `{"name":"tester"}`
 	expResPayload := `{"greeting":"` + expGreeting + `"}`
-	tr.Bind(expReceiver, expEndpoint, transport.HandlerFunc(
+	tr.Bind("", expReceiver, expEndpoint, transport.HandlerFunc(
 		func(req transport.ImmutableMessage, res transport.Message) {
 			payload, _ := req.Payload()
 			payloadStr := string(payload)
@@ -169,7 +169,7 @@ func TestClientMiddlewareChain(t *testing.T) {
 	expEndpoint := "test"
 	expResPayload := `{"hello":"back"}`
 
-	tr.Bind(expReceiver, expEndpoint, transport.HandlerFunc(
+	tr.Bind("", expReceiver, expEndpoint, transport.HandlerFunc(
 		func(req transport.ImmutableMessage, res transport.Message) {
 			res.SetPayload([]byte(expResPayload), nil)
 			<-time.After(100 * time.Millisecond)
@@ -296,8 +296,8 @@ func TestClientErrors(t *testing.T) {
 	tr := provider.NewInMemory()
 	defer tr.Close()
 
-	var invocation int32 = 0
-	tr.Bind("service", "endpoint", transport.HandlerFunc(
+	var invocation int32
+	tr.Bind("", "service", "endpoint", transport.HandlerFunc(
 		func(req transport.ImmutableMessage, res transport.Message) {
 			invocation := atomic.AddInt32(&invocation, 1)
 			// first two invocations succeed

--- a/client/middleware.go
+++ b/client/middleware.go
@@ -7,7 +7,7 @@ import (
 )
 
 // A MiddlewareFactory generates a Middleware instances.
-type MiddlewareFactory func() Middleware
+type MiddlewareFactory func(serviceName string) Middleware
 
 // Middleware is an interface implemented by objects that can be injected into
 // a client's outgoing request flow.

--- a/client/middleware/circuitbreaker/circuitbreaker.go
+++ b/client/middleware/circuitbreaker/circuitbreaker.go
@@ -48,7 +48,7 @@ const (
 // returns a singleton circuit-breaker instance using the supplied configuration.
 func SingletonFactory(cfg Config) client.MiddlewareFactory {
 	cb := newCiruitBreaker(cfg)
-	return func() client.Middleware {
+	return func(_ string) client.Middleware {
 		return cb
 	}
 }
@@ -56,7 +56,7 @@ func SingletonFactory(cfg Config) client.MiddlewareFactory {
 // Factory generates a circuit-breaker middleware factory that returns new
 // circuit-breaker instances using the supplied configuration.
 func Factory(cfg Config) client.MiddlewareFactory {
-	return func() client.Middleware {
+	return func(_ string) client.Middleware {
 		return newCiruitBreaker(cfg)
 	}
 }

--- a/client/middleware/circuitbreaker/circuitbreaker_test.go
+++ b/client/middleware/circuitbreaker/circuitbreaker_test.go
@@ -15,8 +15,8 @@ import (
 func TestFactory(t *testing.T) {
 	f := Factory(&StaticConfig{})
 
-	m1 := f().(*circuitBreaker)
-	m2 := f().(*circuitBreaker)
+	m1 := f("").(*circuitBreaker)
+	m2 := f("").(*circuitBreaker)
 
 	if m1 == m2 {
 		t.Fatalf("expected Factory to return different instance")
@@ -59,8 +59,8 @@ func TestFactory(t *testing.T) {
 func TestSingletonFactory(t *testing.T) {
 	f := SingletonFactory(&StaticConfig{})
 
-	m1 := f().(*circuitBreaker)
-	m2 := f().(*circuitBreaker)
+	m1 := f("").(*circuitBreaker)
+	m2 := f("").(*circuitBreaker)
 
 	if m1 != m2 {
 		t.Fatalf("expected SingletonFactory to return the same instance")

--- a/client/middleware/weightedrouting/weighted_routing.go
+++ b/client/middleware/weightedrouting/weighted_routing.go
@@ -1,0 +1,150 @@
+// Package weightedrouting provides a middleware that sets each outgoing
+// request's version by sampling the random number generator and then
+// consulting is routing table that assigns a weight to each version.
+//
+// The middleware obtains its configuration from the global configuration
+// store and its meant to be used in conjunction with a dynamic configuration
+// provider.
+//
+// Potential use-cases for this middleware include blue-green deployments
+// (http://martinfowler.com/bliki/BlueGreenDeployment.html) and canary releases
+// (http://martinfowler.com/bliki/CanaryRelease.html) where a new service version
+// is rolled out to production and a small amount of traffic is routed to it so
+// it can be tested.
+package weightedrouting
+
+import (
+	"context"
+	"math/rand"
+	"runtime"
+	"strconv"
+	"sync"
+
+	"github.com/achilleasa/usrv/client"
+	"github.com/achilleasa/usrv/config"
+	"github.com/achilleasa/usrv/config/flag"
+	"github.com/achilleasa/usrv/transport"
+)
+
+// Values overwritten by tests
+var (
+	setFinalizer = runtime.SetFinalizer
+	randFloat32  = rand.Float32
+	cfgStore     = &config.Store
+)
+
+// Factory generates a weighted-routing middleware factory that returns new
+// weighted-router instances. Each instance obtains its weight configuration
+// by monitoring keys under the namespace "weighted_router/$serviceName". Each
+// key under this namespace points to a version name and its value should contain
+// the weight assigned to that version name (0 to 1.0 range). All weights should
+// sum to 1.0.
+//
+// For example, given a service called "foo" for which we want to route 30% of
+// the traffic to "v0" and 70% of the traffic to "v1", the following configuration
+// keys need to be defined:
+//  - weighted_router/foo/v0 -> "0.3"
+//  - weighted_router/foo/v1 -> "0.7"
+func Factory() client.MiddlewareFactory {
+	return func(serviceName string) client.Middleware {
+		return newRouter(serviceName)
+	}
+}
+
+// route combines a route version and a weight for selecting that route.
+type route struct {
+	version string
+	weight  float32
+}
+
+// router is a client middleware that sets the requested service version
+// for outgoing messages by consulting a set of weights obtained via a dynamic
+// configuration flag.
+type router struct {
+	// A RW mutex used for synchronizing access to the routing table.
+	mutex sync.RWMutex
+
+	// The list of versioned routes and their selection probabilites.
+	routes []route
+
+	// A flag providing the weight configurations.
+	weightCfg *flag.Map
+
+	// A channel to signal the config monitor to exit.
+	doneChan chan struct{}
+}
+
+// newRouter creates a weighted router instance that fetches its weights
+// using the following configuration key: "weighted_router/$serviceName/".
+func newRouter(serviceName string) *router {
+	wr := &router{
+		weightCfg: flag.NewMap(cfgStore, "weighted_router/"+serviceName),
+		doneChan:  make(chan struct{}, 0),
+	}
+
+	// fetch initial weights
+	wr.updateWeights()
+	wr.spawnChangeMonitor()
+	setFinalizer(wr, func(wr *router) { close(wr.doneChan) })
+
+	return wr
+}
+
+// spawnChangeMonitor starts a worker that istens for configuration weight changes
+// and updates the middleware's routing table.
+func (wr *router) spawnChangeMonitor() {
+	go func() {
+		for {
+			select {
+			case <-wr.doneChan:
+				wr.weightCfg.CancelDynamicUpdates()
+				return
+			case <-wr.weightCfg.ChangeChan():
+				wr.updateWeights()
+			}
+		}
+	}()
+}
+
+// updateWeights fetches the latest routing weights configuration and updates
+// the internal routes table.
+func (wr *router) updateWeights() {
+	wr.mutex.Lock()
+	cfg := wr.weightCfg.Get()
+
+	routes := make([]route, 0)
+	for version, weightStr := range cfg {
+		weight, err := strconv.ParseFloat(weightStr, 32)
+		if err != nil {
+			continue
+		}
+		routes = append(routes, route{version, float32(weight)})
+	}
+
+	wr.routes = routes
+	wr.mutex.Unlock()
+}
+
+// Pre implements a pre-hook as part of the client Middleware interface.
+func (wr *router) Pre(ctx context.Context, req transport.Message) (context.Context, error) {
+	prob := randFloat32()
+
+	wr.mutex.RLock()
+
+	var probIntegral float32
+	for _, route := range wr.routes {
+		probIntegral += route.weight
+
+		if prob <= probIntegral {
+			req.SetReceiverVersion(route.version)
+			break
+		}
+	}
+
+	wr.mutex.RUnlock()
+	return ctx, nil
+}
+
+// Post implements a post-hook as part of the client Middleware interface.
+func (wr *router) Post(_ context.Context, _, _ transport.ImmutableMessage) {
+}

--- a/client/middleware/weightedrouting/weighted_routing_test.go
+++ b/client/middleware/weightedrouting/weighted_routing_test.go
@@ -1,0 +1,261 @@
+package weightedrouting
+
+import (
+	"context"
+	"math/rand"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/achilleasa/usrv/config"
+	"github.com/achilleasa/usrv/config/store"
+	"github.com/achilleasa/usrv/transport"
+)
+
+func TestRouter(t *testing.T) {
+	defer func() {
+		cfgStore = &config.Store
+		randFloat32 = rand.Float32
+	}()
+
+	var randMutex sync.Mutex
+	var randValues = []float32{0, 0.2999, 0.6999, 0.8, 0.2, 0.9, 0.9999}
+	randFloat32 = func() float32 {
+		randMutex.Lock()
+		defer randMutex.Unlock()
+		nextVal := randValues[0]
+		randValues = randValues[1:]
+		return nextVal
+	}
+
+	var s store.Store
+	cfgStore = &s
+
+	s.SetKeys(
+		1,
+		"weighted_router/foo",
+		map[string]string{
+			"v0": "0.3",
+			"v1": "0.7",
+		},
+	)
+
+	f := Factory()
+	m := f("foo").(*router)
+	ctx := context.Background()
+
+	req := transport.MakeGenericMessage()
+	defer req.Close()
+
+	// Since map accesses in go are random we need to check the decoded
+	// route order to select the expectations
+	var expectedVersions []string
+	switch m.routes[0].version {
+	case "v0":
+		expectedVersions = []string{"v0", "v0", "v1", "v1", "v0", "v1", "v1"}
+	default:
+		expectedVersions = []string{"v1", "v1", "v1", "v0", "v1", "v0", "v0"}
+	}
+
+	for specIndex, expVersion := range expectedVersions {
+		req.SetReceiverVersion("")
+		_, err := m.Pre(ctx, req)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		version := req.ReceiverVersion()
+		if version != expVersion {
+			t.Errorf("[spec %d] expected middlware to set receiver version %q; got %q", specIndex, expVersion, version)
+		}
+	}
+
+	// Change the weights so that we always prefer version v0
+	s.SetKeys(
+		1,
+		"weighted_router/foo",
+		map[string]string{
+			"v0": "1.0",
+			"v1": "0",
+			"v2": "not-a-float",
+		},
+	)
+
+	<-time.After(100 * time.Millisecond)
+
+	// Reset RND
+	randValues = []float32{0, 0.2999, 0.6999, 0.8, 0.2, 0.9, 0.9999}
+
+	expVersion := "v0"
+	for specIndex := range expectedVersions {
+		req.SetReceiverVersion("")
+		_, err := m.Pre(ctx, req)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		m.Post(ctx, req, nil)
+
+		version := req.ReceiverVersion()
+		if version != expVersion {
+			t.Errorf("[spec %d] expected middlware to set receiver version %q; got %q", specIndex, expVersion, version)
+		}
+	}
+}
+
+func TestRouterLocks(t *testing.T) {
+	defer func() {
+		cfgStore = &config.Store
+		randFloat32 = rand.Float32
+	}()
+
+	var randMutex sync.Mutex
+	var randValues = []float32{0, 0.2999, 0.6999, 0.8, 0.2, 0.9, 0.9999}
+	randFloat32 = func() float32 {
+		randMutex.Lock()
+		defer randMutex.Unlock()
+		nextVal := randValues[0]
+		randValues = randValues[1:]
+		return nextVal
+	}
+
+	var s store.Store
+	cfgStore = &s
+
+	s.SetKeys(
+		1,
+		"weighted_router/foo",
+		map[string]string{
+			"v0": "0.3",
+			"v1": "0.7",
+		},
+	)
+
+	f := Factory()
+	m := f("foo").(*router)
+	ctx := context.Background()
+
+	versionChan := make(chan string, len(randValues))
+	var wg sync.WaitGroup
+	wg.Add(len(randValues))
+	for _ = range randValues {
+		go func() {
+			req := transport.MakeGenericMessage()
+			defer func() {
+				req.Close()
+				wg.Done()
+			}()
+
+			_, err := m.Pre(ctx, req)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			m.Post(ctx, req, nil)
+			versionChan <- req.ReceiverVersion()
+		}()
+	}
+
+	wg.Wait()
+	close(versionChan)
+
+	var expV0, expV1 int = 3, 4
+	var v0, v1 int
+	for v := range versionChan {
+		switch v {
+		case "v0":
+			v0++
+		case "v1":
+			v1++
+		}
+	}
+
+	if v0 != expV0 || v1 != expV1 {
+		t.Fatalf("expected v0 and v1 counts to be %d, %d; got %d, %d", expV0, expV1, v0, v1)
+	}
+
+	// Reset RND
+	randValues = []float32{0, 0.2999, 0.6999, 0.8, 0.2, 0.9, 0.9999}
+	wg.Add(len(randValues))
+
+	for _ = range randValues {
+		go func() {
+			req := transport.MakeGenericMessage()
+			defer func() {
+				req.Close()
+				wg.Done()
+			}()
+
+			_, err := m.Pre(ctx, req)
+			if err != nil {
+				t.Fatal(err)
+			}
+			m.Post(ctx, req, nil)
+		}()
+	}
+
+	// Change the weights so that we always prefer version v0
+	s.SetKeys(
+		1,
+		"weighted_router/foo",
+		map[string]string{
+			"v0": "1.0",
+			"v1": "0",
+		},
+	)
+
+	wg.Wait()
+}
+
+func TestWorkerCleanup(t *testing.T) {
+	origSetFinalizer := setFinalizer
+	defer func() {
+		setFinalizer = origSetFinalizer
+	}()
+	var finalizer func(*router)
+	setFinalizer = func(_ interface{}, cb interface{}) {
+		finalizer = cb.(func(*router))
+	}
+
+	var s store.Store
+	cfgStore = &s
+
+	s.SetKeys(
+		1,
+		"weighted_router/foo",
+		map[string]string{
+			"v1": "1.0",
+		},
+	)
+
+	f := Factory()
+	m := f("foo").(*router)
+	ctx := context.Background()
+
+	// Shutdown worker
+	finalizer(m)
+	<-time.After(100 * time.Millisecond)
+
+	// Trigger store update; these changes will not be picked up by the middleware
+	s.SetKeys(
+		1,
+		"weighted_router/foo",
+		map[string]string{
+			"v0": "1.0",
+		},
+	)
+	<-time.After(100 * time.Millisecond)
+
+	expVersion := "v1"
+	req := transport.MakeGenericMessage()
+	defer req.Close()
+	_, err := m.Pre(ctx, req)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	version := req.ReceiverVersion()
+	if version != expVersion {
+		t.Error("expected middlware not to update its routing weights after its finalizer gets called")
+	}
+}

--- a/client/option.go
+++ b/client/option.go
@@ -35,7 +35,7 @@ func WithMiddleware(factories ...MiddlewareFactory) Option {
 			if factory == nil {
 				continue
 			}
-			list = append(list, factory())
+			list = append(list, factory(s.serviceName))
 		}
 
 		s.middleware = append(s.middleware, list...)

--- a/server/option.go
+++ b/server/option.go
@@ -33,3 +33,12 @@ func WithPanicHandler(handler PanicHandler) Option {
 		return nil
 	}
 }
+
+// WithVersion defines the version of the service provided by the server.
+// The version value is passed to Bind calls to the underlying transport.
+func WithVersion(version string) Option {
+	return func(s *Server) error {
+		s.serviceVersion = version
+		return nil
+	}
+}

--- a/server/server.go
+++ b/server/server.go
@@ -66,6 +66,9 @@ type Server struct {
 	// The name of the service exposed by the server.
 	serviceName string
 
+	// The service version
+	serviceVersion string
+
 	// The set of defined endpoints.
 	endpoints []*Endpoint
 
@@ -127,7 +130,7 @@ func (s *Server) Listen() error {
 
 	var err error
 	for _, endpoint := range s.endpoints {
-		err = s.transport.Bind(s.serviceName, endpoint.Name, s.generateHandler(endpoint))
+		err = s.transport.Bind(s.serviceVersion, s.serviceName, endpoint.Name, s.generateHandler(endpoint))
 		if err != nil {
 			s.mutex.Unlock()
 			return err

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -234,6 +234,7 @@ func TestMarshalingErrorHandling(t *testing.T) {
 
 	codec := nopCodec()
 	srv, err := New(
+
 		"test",
 		WithCodec(codec),
 	)
@@ -313,6 +314,7 @@ func TestPanicHandling(t *testing.T) {
 	}
 
 	srv, err := New(
+
 		"test",
 		WithCodec(nopCodec()),
 		WithPanicHandler(panicHandler),
@@ -443,6 +445,7 @@ func TestListenErrors(t *testing.T) {
 
 	srv, err := New(
 		"test",
+		WithVersion("v0"),
 		WithTransport(provider.NewInMemory()),
 	)
 	if err != nil {
@@ -470,7 +473,7 @@ func TestListenErrors(t *testing.T) {
 	}
 
 	err = srv.Listen()
-	expErrorMsg := `binding "test/test" already defined`
+	expErrorMsg := `binding "test-v0/test" already defined`
 	if err == nil || (err != nil && err.Error() != expErrorMsg) {
 		t.Fatalf("expected error %q; got %v", expErrorMsg, err)
 	}
@@ -533,7 +536,7 @@ func (tr *testTransportThatFailsDialing) Request(_ transport.Message) <-chan tra
 	return nil
 }
 
-func (tr *testTransportThatFailsDialing) Bind(_, _ string, _ transport.Handler) error {
+func (tr *testTransportThatFailsDialing) Bind(_, _, _ string, _ transport.Handler) error {
 	return nil
 }
 

--- a/transport/message.go
+++ b/transport/message.go
@@ -23,6 +23,9 @@ type ImmutableMessage interface {
 	// ReceiverEndpoint returns the endpoint where the message should be delivered at.
 	ReceiverEndpoint() string
 
+	// ReceiverVersion returns the requested receiving service's version.
+	ReceiverVersion() string
+
 	// Headers returns a map of header values associated with the message.
 	Headers() map[string]string
 
@@ -52,4 +55,7 @@ type Message interface {
 	// SetHeaders sets the contents of a batch of headers. This is equivalent
 	// to iterating the map and calling SetHeader for each key/value.
 	SetHeaders(headers map[string]string)
+
+	// SetReceiverVersion sets the required version for the receiving service.
+	SetReceiverVersion(string)
 }

--- a/transport/message_impl.go
+++ b/transport/message_impl.go
@@ -25,6 +25,7 @@ type GenericMessage struct {
 	ReceiverField         string
 	SenderEndpointField   string
 	ReceiverEndpointField string
+	ReceiverVersionField  string
 	HeadersField          map[string]string
 	PayloadField          []byte
 	ErrField              error
@@ -60,6 +61,16 @@ func (m *GenericMessage) SenderEndpoint() string {
 // ReceiverEndpoint returns the receiving service's endpoint.
 func (m *GenericMessage) ReceiverEndpoint() string {
 	return m.ReceiverEndpointField
+}
+
+// ReceiverVersion returns the requested receiving service's version.
+func (m *GenericMessage) ReceiverVersion() string {
+	return m.ReceiverVersionField
+}
+
+// SetReceiverVersion sets the requested receiving service's version.
+func (m *GenericMessage) SetReceiverVersion(version string) {
+	m.ReceiverVersionField = version
 }
 
 // Headers returns a map of header values associated with the message.
@@ -105,6 +116,7 @@ func MakeGenericMessage() *GenericMessage {
 	m.HeadersField = make(map[string]string, 0)
 	m.PayloadField = nil
 	m.ErrField = nil
+	m.ReceiverVersionField = ""
 	return m
 }
 

--- a/transport/message_impl_test.go
+++ b/transport/message_impl_test.go
@@ -46,6 +46,19 @@ func TestGenericMessage(t *testing.T) {
 	if m.ReceiverEndpoint() != expValue {
 		t.Errorf("expected ReceiverEndpoint() to return %q; got %q", expValue, m.ReceiverEndpoint())
 	}
+
+	expValue = "v0"
+	m.ReceiverVersionField = expValue
+	if m.ReceiverVersion() != expValue {
+		t.Errorf("expected ReceiverVersion() to return %q; got %q", expValue, m.ReceiverVersion())
+	}
+
+	expValue = "v1"
+	m.SetReceiverVersion(expValue)
+	if m.ReceiverVersion() != expValue {
+		t.Errorf("expected SetReceiverVersion(%q) to update the version; got %q", expValue, m.ReceiverVersion())
+	}
+
 	expValue = "foo"
 	m.SetHeader("kEy1", expValue)
 	if m.Headers()["Key1"] != expValue {

--- a/transport/transport.go
+++ b/transport/transport.go
@@ -36,9 +36,12 @@ type Transport interface {
 	// Bind listens for messages send to a particular service and
 	// endpoint combination and invokes the supplied handler to process them.
 	//
+	// Transports may implement versioning for bindings in order to support
+	// complex deployment flows such as blue-green deployments.
+	//
 	// Bindings can only be established on a closed transport. Calls to Bind
 	// after a call to Dial will result in an error.
-	Bind(service, endpoint string, handler Handler) error
+	Bind(version, service, endpoint string, handler Handler) error
 
 	// Request performs an RPC and returns back a read-only channel for
 	// receiving the result.


### PR DESCRIPTION
This PR adds versioning support for services and provides the weighted-routing middleware that allows control of the traffic sent to each service using a dynamic configuration provider.