### PR TITLE
Extract transports to packages

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -20,7 +20,7 @@ import (
 // usrv.DefaultTransportFactory to fetch a transport instance.
 type Client struct {
 	// The transport used by the client.
-	transport transport.Transport
+	transport transport.Provider
 
 	// A codec instance for handling marshaling/unmarshaling.
 	codec encoding.Codec

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/achilleasa/usrv/encoding"
 	"github.com/achilleasa/usrv/server"
 	"github.com/achilleasa/usrv/transport"
-	"github.com/achilleasa/usrv/transport/provider"
+	"github.com/achilleasa/usrv/transport/memory"
 )
 
 func TestClientOptionError(t *testing.T) {
@@ -24,7 +24,7 @@ func TestClientOptionError(t *testing.T) {
 }
 
 func TestClientRequest(t *testing.T) {
-	tr := provider.NewInMemory()
+	tr := memory.NewInMemory()
 	defer tr.Close()
 
 	expGreeting := "hello tester"
@@ -81,7 +81,7 @@ func TestClientRequest(t *testing.T) {
 }
 
 func TestClientRequestWithServerEndpointCtx(t *testing.T) {
-	tr := provider.NewInMemory()
+	tr := memory.NewInMemory()
 	defer tr.Close()
 
 	expSender := "foo service"
@@ -161,7 +161,7 @@ func TestClientMiddlewareChain(t *testing.T) {
 	}()
 	ClearGlobalMiddlewareFactories()
 
-	tr := provider.NewInMemory()
+	tr := memory.NewInMemory()
 	defer tr.Close()
 
 	expReceiver := "service"
@@ -253,7 +253,7 @@ func TestClientMiddlewareChain(t *testing.T) {
 }
 
 func TestClientMiddlewareThatAbortsRequestExecution(t *testing.T) {
-	tr := provider.NewInMemory()
+	tr := memory.NewInMemory()
 	defer tr.Close()
 
 	logChan := make(chan string, 8)
@@ -293,7 +293,7 @@ func TestClientMiddlewareThatAbortsRequestExecution(t *testing.T) {
 }
 
 func TestClientErrors(t *testing.T) {
-	tr := provider.NewInMemory()
+	tr := memory.NewInMemory()
 	defer tr.Close()
 
 	var invocation int32

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -24,7 +24,7 @@ func TestClientOptionError(t *testing.T) {
 }
 
 func TestClientRequest(t *testing.T) {
-	tr := memory.NewInMemory()
+	tr := memory.New()
 	defer tr.Close()
 
 	expGreeting := "hello tester"
@@ -81,7 +81,7 @@ func TestClientRequest(t *testing.T) {
 }
 
 func TestClientRequestWithServerEndpointCtx(t *testing.T) {
-	tr := memory.NewInMemory()
+	tr := memory.New()
 	defer tr.Close()
 
 	expSender := "foo service"
@@ -161,7 +161,7 @@ func TestClientMiddlewareChain(t *testing.T) {
 	}()
 	ClearGlobalMiddlewareFactories()
 
-	tr := memory.NewInMemory()
+	tr := memory.New()
 	defer tr.Close()
 
 	expReceiver := "service"
@@ -253,7 +253,7 @@ func TestClientMiddlewareChain(t *testing.T) {
 }
 
 func TestClientMiddlewareThatAbortsRequestExecution(t *testing.T) {
-	tr := memory.NewInMemory()
+	tr := memory.New()
 	defer tr.Close()
 
 	logChan := make(chan string, 8)
@@ -293,7 +293,7 @@ func TestClientMiddlewareThatAbortsRequestExecution(t *testing.T) {
 }
 
 func TestClientErrors(t *testing.T) {
-	tr := memory.NewInMemory()
+	tr := memory.New()
 	defer tr.Close()
 
 	var invocation int32

--- a/client/option.go
+++ b/client/option.go
@@ -10,7 +10,7 @@ type Option func(s *Client) error
 
 // WithTransport configures the client to use a specific transport instead
 // of the default transport.
-func WithTransport(transport transport.Transport) Option {
+func WithTransport(transport transport.Provider) Option {
 	return func(s *Client) error {
 		s.transport = transport
 		return nil

--- a/factory.go
+++ b/factory.go
@@ -4,7 +4,7 @@ import (
 	"github.com/achilleasa/usrv/encoding"
 	"github.com/achilleasa/usrv/encoding/json"
 	"github.com/achilleasa/usrv/transport"
-	"github.com/achilleasa/usrv/transport/provider"
+	"github.com/achilleasa/usrv/transport/http"
 )
 
 var (
@@ -25,6 +25,6 @@ var (
 )
 
 func init() {
-	DefaultTransportFactory = provider.HTTPTransportFactory
+	DefaultTransportFactory = http.HTTPTransportFactory
 	DefaultCodecFactory = json.Codec
 }

--- a/factory.go
+++ b/factory.go
@@ -13,7 +13,7 @@ var (
 	//
 	// When usrv is imported, DefaultTransportFactory is set up to return
 	// HTTP transport instances.
-	DefaultTransportFactory func() transport.Transport
+	DefaultTransportFactory func() transport.Provider
 
 	// DefaultCodecFactory is a function that returns back a new
 	// instance of the default Codec used for marshaling and unmarshaling

--- a/factory.go
+++ b/factory.go
@@ -25,6 +25,6 @@ var (
 )
 
 func init() {
-	DefaultTransportFactory = http.HTTPTransportFactory
+	DefaultTransportFactory = http.Factory
 	DefaultCodecFactory = json.Codec
 }

--- a/server/middleware/concurrency/max_concurrent_test.go
+++ b/server/middleware/concurrency/max_concurrent_test.go
@@ -23,7 +23,7 @@ func TestSingletonFactory(t *testing.T) {
 		SingletonFactory(&StaticConfig{1, 100 * time.Millisecond}),
 	}
 
-	tr := memory.NewInMemory()
+	tr := memory.New()
 	defer tr.Close()
 	srv, err := server.New(
 		"test",
@@ -166,7 +166,7 @@ func TestFactory(t *testing.T) {
 		Factory(&StaticConfig{1, 100 * time.Millisecond}),
 	}
 
-	tr := memory.NewInMemory()
+	tr := memory.New()
 	defer tr.Close()
 	srv, err := server.New(
 		"test",

--- a/server/middleware/concurrency/max_concurrent_test.go
+++ b/server/middleware/concurrency/max_concurrent_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/achilleasa/usrv/config/store"
 	"github.com/achilleasa/usrv/server"
 	"github.com/achilleasa/usrv/transport"
-	"github.com/achilleasa/usrv/transport/provider"
+	"github.com/achilleasa/usrv/transport/memory"
 )
 
 func TestSingletonFactory(t *testing.T) {
@@ -23,7 +23,7 @@ func TestSingletonFactory(t *testing.T) {
 		SingletonFactory(&StaticConfig{1, 100 * time.Millisecond}),
 	}
 
-	tr := provider.NewInMemory()
+	tr := memory.NewInMemory()
 	defer tr.Close()
 	srv, err := server.New(
 		"test",
@@ -166,7 +166,7 @@ func TestFactory(t *testing.T) {
 		Factory(&StaticConfig{1, 100 * time.Millisecond}),
 	}
 
-	tr := provider.NewInMemory()
+	tr := memory.NewInMemory()
 	defer tr.Close()
 	srv, err := server.New(
 		"test",

--- a/server/option.go
+++ b/server/option.go
@@ -10,7 +10,7 @@ type Option func(s *Server) error
 
 // WithTransport configures the server to use a specific transport instead
 // of the default transport.
-func WithTransport(transport transport.Transport) Option {
+func WithTransport(transport transport.Provider) Option {
 	return func(s *Server) error {
 		s.transport = transport
 		return nil

--- a/server/server.go
+++ b/server/server.go
@@ -55,7 +55,7 @@ type Server struct {
 	mutex sync.Mutex
 
 	// The transport used by the server.
-	transport transport.Transport
+	transport transport.Provider
 
 	// A codec instance for handling marshaling/unmarshaling.
 	codec encoding.Codec

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -372,7 +372,7 @@ func TestServer(t *testing.T) {
 
 	srv, err := New(
 		"test",
-		WithTransport(memory.NewInMemory()),
+		WithTransport(memory.New()),
 	)
 	if err != nil {
 		t.Fatal(err)
@@ -446,7 +446,7 @@ func TestListenErrors(t *testing.T) {
 	srv, err := New(
 		"test",
 		WithVersion("v0"),
-		WithTransport(memory.NewInMemory()),
+		WithTransport(memory.New()),
 	)
 	if err != nil {
 		t.Fatal(err)

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/achilleasa/usrv/encoding"
 	"github.com/achilleasa/usrv/encoding/json"
 	"github.com/achilleasa/usrv/transport"
-	"github.com/achilleasa/usrv/transport/provider"
+	"github.com/achilleasa/usrv/transport/memory"
 )
 
 func TestOptionsThatReturnErrors(t *testing.T) {
@@ -372,7 +372,7 @@ func TestServer(t *testing.T) {
 
 	srv, err := New(
 		"test",
-		WithTransport(provider.NewInMemory()),
+		WithTransport(memory.NewInMemory()),
 	)
 	if err != nil {
 		t.Fatal(err)
@@ -446,7 +446,7 @@ func TestListenErrors(t *testing.T) {
 	srv, err := New(
 		"test",
 		WithVersion("v0"),
-		WithTransport(provider.NewInMemory()),
+		WithTransport(memory.NewInMemory()),
 	)
 	if err != nil {
 		t.Fatal(err)

--- a/transport/http/http.go
+++ b/transport/http/http.go
@@ -1,4 +1,4 @@
-package provider
+package http
 
 import (
 	"bytes"

--- a/transport/http/http.go
+++ b/transport/http/http.go
@@ -54,7 +54,7 @@ var (
 )
 
 var (
-	_ transport.Transport = &Transport{}
+	_ transport.Provider = &Transport{}
 )
 
 // Binding encapsulates the details of a service/endpoint combination and
@@ -706,7 +706,7 @@ func (t *Transport) buildTLSConfig() (tlsConfig *tls.Config, err error) {
 // whose concrete implementation is the HTTP transport. This function behaves
 // exactly the same as New() but returns back a Transport interface allowing
 // it to be used as usrv.DefaultTransportFactory.
-func Factory() transport.Transport {
+func Factory() transport.Provider {
 	return New()
 }
 

--- a/transport/http/http_test.go
+++ b/transport/http/http_test.go
@@ -20,7 +20,7 @@ import (
 )
 
 func TestHTTPErrors(t *testing.T) {
-	tr := NewHTTP()
+	tr := New()
 	tr.port.Set(9901)
 	tr.URLBuilder = testURLBuilder{addr: "http://localhost:9901"}
 	defer tr.Close()
@@ -114,7 +114,7 @@ func TestHTTPErrors(t *testing.T) {
 }
 
 func TestTLSErrors(t *testing.T) {
-	tr := NewHTTP()
+	tr := New()
 	tr.port.Set(9444)
 	tr.protocol.Set("https")
 
@@ -225,7 +225,7 @@ func TestTLSErrors(t *testing.T) {
 }
 
 func TestHTTPErrorPropagation(t *testing.T) {
-	tr := NewHTTP()
+	tr := New()
 	tr.port.Set(9902)
 	tr.URLBuilder = testURLBuilder{addr: "http://localhost:9902"}
 	defer tr.Close()
@@ -288,7 +288,7 @@ func TestHTTPErrorPropagation(t *testing.T) {
 }
 
 func TestRPCOverHTTP(t *testing.T) {
-	tr := NewHTTP()
+	tr := New()
 	tr.port.Set(9903)
 	tr.URLBuilder = testURLBuilder{addr: "http://localhost:9903"}
 	defer tr.Close()
@@ -421,7 +421,7 @@ func TestRPCOverHTTPS(t *testing.T) {
 	defer os.Remove(keyFile)
 
 	// By default, the http provider will add the certificate to the system's certificate pool.
-	tr := NewHTTP()
+	tr := New()
 	tr.port.Set(9443)
 	tr.protocol.Set("https")
 	tr.tlsStrictMode.Set(true)
@@ -496,7 +496,7 @@ func TestHTTPReconfiguration(t *testing.T) {
 		"tls/key":           keyFile,
 	})
 
-	tr := NewHTTP()
+	tr := New()
 	tr.URLBuilder = newDefaultURLBuilder()
 	defer tr.Close()
 
@@ -581,8 +581,8 @@ func TestHTTPClientReconfiguration(t *testing.T) {
 		"tls/key":           keyFile,
 	})
 
-	trServer := HTTPTransportFactory()
-	trClient := NewHTTP()
+	trServer := Factory()
+	trClient := New()
 	trClient.URLBuilder = newDefaultURLBuilder()
 	defer trServer.Close()
 	defer trClient.Close()
@@ -624,12 +624,12 @@ func TestHTTPConfigWorkerCleanup(t *testing.T) {
 	defer func() {
 		setFinalizer = origSetFinalizer
 	}()
-	var finalizer func(*HTTP)
+	var finalizer func(*Transport)
 	setFinalizer = func(_ interface{}, cb interface{}) {
-		finalizer = cb.(func(*HTTP))
+		finalizer = cb.(func(*Transport))
 	}
 
-	tr := NewHTTP()
+	tr := New()
 	finalizer(tr)
 	time.After(500 * time.Millisecond)
 

--- a/transport/http/http_test.go
+++ b/transport/http/http_test.go
@@ -1,4 +1,4 @@
-package provider
+package http
 
 import (
 	"crypto/tls"
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"os"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
@@ -752,4 +753,17 @@ yRVjlpqDKQEAAtSLyU7rvW6Im0uwThEzrsMnxPXA2gPNfDN9TwWhtxY=
 	kf.Close()
 
 	return cf.Name(), kf.Name()
+}
+
+func newMessage(from, to string) transport.Message {
+	fromFields := strings.Split(from, "/")
+	toFields := strings.Split(to, "/")
+
+	m := transport.MakeGenericMessage()
+	m.SenderField = fromFields[0]
+	m.SenderEndpointField = fromFields[1]
+	m.ReceiverField = toFields[0]
+	m.ReceiverEndpointField = toFields[1]
+
+	return m
 }

--- a/transport/memory/in_memory.go
+++ b/transport/memory/in_memory.go
@@ -9,7 +9,7 @@ import (
 )
 
 var (
-	_ transport.Transport = &Transport{}
+	_ transport.Provider = &Transport{}
 )
 
 // Transport implements the in-memory transport. It uses channels and go-routines
@@ -124,6 +124,6 @@ func (t *Transport) Request(msg transport.Message) <-chan transport.ImmutableMes
 // whose concrete implementation is the InMemory transport. This function behaves
 // exactly the same as New() but returns back a Transport interface allowing
 // it to be used as usrv.DefaultTransportFactory.
-func Factory() transport.Transport {
+func Factory() transport.Provider {
 	return New()
 }

--- a/transport/memory/in_memory.go
+++ b/transport/memory/in_memory.go
@@ -1,4 +1,4 @@
-// Package provider contains implementations for the built-in usrv transports.
+// Package memory provides an in-memory usrv transport using go channels.
 package memory
 
 import (
@@ -9,28 +9,28 @@ import (
 )
 
 var (
-	_ transport.Transport = &InMemory{}
+	_ transport.Transport = &Transport{}
 )
 
-// InMemory implements the in-memory transport. It uses channels and go-routines
+// Transport implements the in-memory transport. It uses channels and go-routines
 // to facilitate the exchange of messages making it very easy to use when
 // writing tests.
-type InMemory struct {
+type Transport struct {
 	mutex  sync.Mutex
 	dialed bool
 
 	bindings map[string]transport.Handler
 }
 
-// NewInMemory creates a new in-memory transport instance.
-func NewInMemory() *InMemory {
-	return &InMemory{
+// New creates a new in-memory transport instance.
+func New() *Transport {
+	return &Transport{
 		bindings: make(map[string]transport.Handler, 0),
 	}
 }
 
 // Dial connects the transport and starts relaying messages.
-func (t *InMemory) Dial() error {
+func (t *Transport) Dial() error {
 	t.mutex.Lock()
 	defer t.mutex.Unlock()
 
@@ -39,7 +39,7 @@ func (t *InMemory) Dial() error {
 }
 
 // Close shuts down the transport.
-func (t *InMemory) Close() error {
+func (t *Transport) Close() error {
 	t.mutex.Lock()
 	defer t.mutex.Unlock()
 
@@ -60,7 +60,7 @@ func (t *InMemory) Close() error {
 //
 // Bindings can only be established on a closed transport. Calls to Bind
 // after a call to Dial will result in an error.
-func (t *InMemory) Bind(version, service, endpoint string, handler transport.Handler) error {
+func (t *Transport) Bind(version, service, endpoint string, handler transport.Handler) error {
 	t.mutex.Lock()
 	defer t.mutex.Unlock()
 
@@ -85,7 +85,7 @@ func (t *InMemory) Bind(version, service, endpoint string, handler transport.Han
 
 // Request performs an RPC and returns back a read-only channel for
 // receiving the result.
-func (t *InMemory) Request(msg transport.Message) <-chan transport.ImmutableMessage {
+func (t *Transport) Request(msg transport.Message) <-chan transport.ImmutableMessage {
 	resChan := make(chan transport.ImmutableMessage, 1)
 
 	// Build destination key for looking up the binding
@@ -120,10 +120,10 @@ func (t *InMemory) Request(msg transport.Message) <-chan transport.ImmutableMess
 	return resChan
 }
 
-// InMemoryTransportFactory is a factory for creating usrv transport instances
+// Factory is a factory for creating usrv transport instances
 // whose concrete implementation is the InMemory transport. This function behaves
-// exactly the same as NewInMemory() but returns back a Transport interface allowing
+// exactly the same as New() but returns back a Transport interface allowing
 // it to be used as usrv.DefaultTransportFactory.
-func InMemoryTransportFactory() transport.Transport {
-	return NewInMemory()
+func Factory() transport.Transport {
+	return New()
 }

--- a/transport/memory/in_memory.go
+++ b/transport/memory/in_memory.go
@@ -1,5 +1,5 @@
 // Package provider contains implementations for the built-in usrv transports.
-package provider
+package memory
 
 import (
 	"fmt"

--- a/transport/memory/in_memory_test.go
+++ b/transport/memory/in_memory_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestInMemoryBindVersions(t *testing.T) {
-	tr := NewInMemory()
+	tr := New()
 	defer tr.Close()
 
 	handler := transport.HandlerFunc(func(_ transport.ImmutableMessage, _ transport.Message) {})
@@ -33,7 +33,7 @@ func TestInMemoryBindVersions(t *testing.T) {
 }
 
 func TestInMemoryErrors(t *testing.T) {
-	tr := NewInMemory()
+	tr := New()
 	defer tr.Close()
 
 	// Send to unknown endpoint
@@ -77,7 +77,7 @@ func TestInMemoryErrors(t *testing.T) {
 }
 
 func TestInMemoryRPC(t *testing.T) {
-	tr := InMemoryTransportFactory()
+	tr := Factory()
 	defer tr.Close()
 
 	expHeaders := map[string]string{
@@ -207,7 +207,7 @@ func BenchmarkInMemory100Workers(b *testing.B) {
 }
 
 func benchInMemory(b *testing.B, workers int) {
-	tr := NewInMemory()
+	tr := New()
 	defer tr.Close()
 
 	payload := []byte("test payload")

--- a/transport/memory/in_memory_test.go
+++ b/transport/memory/in_memory_test.go
@@ -1,4 +1,4 @@
-package provider
+package memory
 
 import (
 	"reflect"

--- a/transport/transport.go
+++ b/transport/transport.go
@@ -22,10 +22,10 @@ func (f HandlerFunc) Process(req ImmutableMessage, res Message) {
 	f(req, res)
 }
 
-// Transport defines an interface implemented by transports that can be used
+// Provider defines an interface implemented by transports that can be used
 // by usrv. The transport layer is responsible for the exchange of encoded
 // messages between RPC clients and servers.
-type Transport interface {
+type Provider interface {
 	// All transports must implement io.Closer to clean up and shutdown.
 	io.Closer
 


### PR DESCRIPTION
This PR extracts the HTTP and InMemory providers into separate packages and renames their constructors and factories to match the package names. 

The transport.Transport interface has also been renamed to transport.Provider