### PR TITLE
Add support for unbinding transport endpoints

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -178,12 +178,16 @@ func (s *Server) Close() {
 	// Wait for the server to ack the close request
 	<-s.doneChan
 
-	// Cleanup the channel
+	// Cleanup
 	s.mutex.Lock()
-	defer s.mutex.Unlock()
+
+	for _, endpoint := range s.endpoints {
+		s.transport.Unbind(s.serviceVersion, s.serviceName, endpoint.Name)
+	}
+
 	close(s.doneChan)
 	s.doneChan = nil
-
+	s.mutex.Unlock()
 }
 
 // setDefaults applies default settings for fields not set by a server option.

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -473,7 +473,7 @@ func TestListenErrors(t *testing.T) {
 	}
 
 	err = srv.Listen()
-	expErrorMsg := `binding "test-v0/test" already defined`
+	expErrorMsg := `binding (version: "v0", service: "test", endpoint: "test") already defined`
 	if err == nil || (err != nil && err.Error() != expErrorMsg) {
 		t.Fatalf("expected error %q; got %v", expErrorMsg, err)
 	}
@@ -538,6 +538,9 @@ func (tr *testTransportThatFailsDialing) Request(_ transport.Message) <-chan tra
 
 func (tr *testTransportThatFailsDialing) Bind(_, _, _ string, _ transport.Handler) error {
 	return nil
+}
+
+func (tr *testTransportThatFailsDialing) Unbind(_, _, _ string) {
 }
 
 func (tr *testTransportThatFailsDialing) Dial() error {

--- a/transport/transport.go
+++ b/transport/transport.go
@@ -38,10 +38,12 @@ type Provider interface {
 	//
 	// Transports may implement versioning for bindings in order to support
 	// complex deployment flows such as blue-green deployments.
-	//
-	// Bindings can only be established on a closed transport. Calls to Bind
-	// after a call to Dial will result in an error.
 	Bind(version, service, endpoint string, handler Handler) error
+
+	// Unbind removes a message handler previously registered by a call to Bind().
+	// Calling Unbind with a (version, service, endpoint) tuple that is not
+	// registered has no effect.
+	Unbind(version, service, endpoint string)
 
 	// Request performs an RPC and returns back a read-only channel for
 	// receiving the result.


### PR DESCRIPTION
This PR introduces a new method to `transport.Provider` which is used by the `Server` implementation to unbind all registered endpoints when the server shuts down. This allows us to share the same transport between multiple servers.

The PR also contains the following transport-related improvements/fixes:
- endpoints can now be bound to transports even if the transport is already dialed
- switch from `sync.Mutex` to `sync.RWMutex` for more efficient synchronization
- fix locking bug in http transport if `http.NewRequest` returns an error