### PR TITLE
Specify mode when dialing transports

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -25,7 +25,18 @@ func TestClientOptionError(t *testing.T) {
 
 func TestClientRequest(t *testing.T) {
 	tr := memory.New()
-	defer tr.Close()
+	err := tr.Dial(transport.ModeClient)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = tr.Dial(transport.ModeServer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		tr.Close(transport.ModeServer)
+		tr.Close(transport.ModeClient)
+	}()
 
 	expGreeting := "hello tester"
 	expReqPayload := `{"name":"tester"}`
@@ -82,7 +93,18 @@ func TestClientRequest(t *testing.T) {
 
 func TestClientRequestWithServerEndpointCtx(t *testing.T) {
 	tr := memory.New()
-	defer tr.Close()
+	err := tr.Dial(transport.ModeClient)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = tr.Dial(transport.ModeServer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		tr.Close(transport.ModeServer)
+		tr.Close(transport.ModeClient)
+	}()
 
 	expSender := "foo service"
 	expEndpoint := "foo endpoint"
@@ -162,7 +184,18 @@ func TestClientMiddlewareChain(t *testing.T) {
 	ClearGlobalMiddlewareFactories()
 
 	tr := memory.New()
-	defer tr.Close()
+	err := tr.Dial(transport.ModeClient)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = tr.Dial(transport.ModeServer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		tr.Close(transport.ModeServer)
+		tr.Close(transport.ModeClient)
+	}()
 
 	expReceiver := "service"
 	expSender := "other service"
@@ -254,7 +287,18 @@ func TestClientMiddlewareChain(t *testing.T) {
 
 func TestClientMiddlewareThatAbortsRequestExecution(t *testing.T) {
 	tr := memory.New()
-	defer tr.Close()
+	err := tr.Dial(transport.ModeClient)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = tr.Dial(transport.ModeServer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		tr.Close(transport.ModeServer)
+		tr.Close(transport.ModeClient)
+	}()
 
 	logChan := make(chan string, 8)
 
@@ -294,7 +338,18 @@ func TestClientMiddlewareThatAbortsRequestExecution(t *testing.T) {
 
 func TestClientErrors(t *testing.T) {
 	tr := memory.New()
-	defer tr.Close()
+	err := tr.Dial(transport.ModeClient)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = tr.Dial(transport.ModeServer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		tr.Close(transport.ModeServer)
+		tr.Close(transport.ModeClient)
+	}()
 
 	var invocation int32
 	tr.Bind("", "service", "endpoint", transport.HandlerFunc(

--- a/factory.go
+++ b/factory.go
@@ -25,6 +25,6 @@ var (
 )
 
 func init() {
-	DefaultTransportFactory = http.Factory
+	DefaultTransportFactory = http.SingletonFactory
 	DefaultCodecFactory = json.Codec
 }

--- a/server/middleware/concurrency/max_concurrent_test.go
+++ b/server/middleware/concurrency/max_concurrent_test.go
@@ -24,7 +24,19 @@ func TestSingletonFactory(t *testing.T) {
 	}
 
 	tr := memory.New()
-	defer tr.Close()
+	err := tr.Dial(transport.ModeClient)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = tr.Dial(transport.ModeServer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		tr.Close(transport.ModeServer)
+		tr.Close(transport.ModeClient)
+	}()
+
 	srv, err := server.New(
 		"test",
 		server.WithTransport(tr),
@@ -167,7 +179,19 @@ func TestFactory(t *testing.T) {
 	}
 
 	tr := memory.New()
-	defer tr.Close()
+	err := tr.Dial(transport.ModeClient)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = tr.Dial(transport.ModeServer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		tr.Close(transport.ModeServer)
+		tr.Close(transport.ModeClient)
+	}()
+
 	srv, err := server.New(
 		"test",
 		server.WithTransport(tr),

--- a/server/server.go
+++ b/server/server.go
@@ -137,7 +137,7 @@ func (s *Server) Listen() error {
 		}
 	}
 
-	err = s.transport.Dial()
+	err = s.transport.Dial(transport.ModeServer)
 	if err != nil {
 		s.mutex.Unlock()
 		return err
@@ -153,7 +153,7 @@ func (s *Server) Listen() error {
 	defer s.mutex.Unlock()
 
 	// Shutdown transport and ack the close request
-	s.transport.Close()
+	s.transport.Close(transport.ModeServer)
 	s.doneChan <- struct{}{}
 
 	return nil

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -528,7 +528,7 @@ func nopCodec() *testCodec {
 type testTransportThatFailsDialing struct {
 }
 
-func (tr *testTransportThatFailsDialing) Close() error {
+func (tr *testTransportThatFailsDialing) Close(_ transport.Mode) error {
 	return nil
 }
 
@@ -543,6 +543,6 @@ func (tr *testTransportThatFailsDialing) Bind(_, _, _ string, _ transport.Handle
 func (tr *testTransportThatFailsDialing) Unbind(_, _, _ string) {
 }
 
-func (tr *testTransportThatFailsDialing) Dial() error {
+func (tr *testTransportThatFailsDialing) Dial(_ transport.Mode) error {
 	return transport.ErrTransportAlreadyDialed
 }

--- a/transport/transport.go
+++ b/transport/transport.go
@@ -1,6 +1,13 @@
 package transport
 
-import "io"
+// Mode describes the way that a transport is being used.
+type Mode bool
+
+// The modes that can be passed to calls to Dial() and Close().
+const (
+	ModeServer Mode = true
+	ModeClient      = false
+)
 
 // A Handler responds to an RPC request.
 //
@@ -26,12 +33,13 @@ func (f HandlerFunc) Process(req ImmutableMessage, res Message) {
 // by usrv. The transport layer is responsible for the exchange of encoded
 // messages between RPC clients and servers.
 type Provider interface {
-	// All transports must implement io.Closer to clean up and shutdown.
-	io.Closer
+	// Dial connects to the transport using the specified dial mode. When
+	// the dial mode is set to DialModeServer the transport will start
+	// relaying messages to registered bindings.
+	Dial(mode Mode) error
 
-	// Dial connects the transport, establishes any declared bindings and
-	// starts relaying messages.
-	Dial() error
+	// Close terminates a dialed connection using the specified dial mode.
+	Close(mode Mode) error
 
 	// Bind listens for messages send to a particular service and
 	// endpoint combination and invokes the supplied handler to process them.


### PR DESCRIPTION
This PR extends the `transport.Provider` interface `Dial` and `Close` methods to accept a `mode` parameter which can take the values `transport.ModeClient` and `transport.ModeServer`. Transports can now implement different code paths depending on the mode value making it much easier to share them between multiple client and server instances. 

In addition, the PR also defines singleton factories for the in-memory and http transports and switches the default transport factory to `http.SingletonFactory`