### PR TITLE
Fix lint warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # usrv
 [![Build Status](https://travis-ci.org/achilleasa/usrv.svg?branch=master)](https://travis-ci.org/achilleasa/usrv)
 [![codecov](https://codecov.io/gh/achilleasa/usrv/branch/master/graph/badge.svg)](https://codecov.io/gh/achilleasa/usrv)
+[![Go Report Card](https://goreportcard.com/badge/github.com/achilleasa/usrv)](https://goreportcard.com/report/github.com/achilleasa/usrv)
 
 A microservice framework for Go

--- a/client/client.go
+++ b/client/client.go
@@ -190,10 +190,5 @@ func (c *Client) Request(ctx context.Context, endpoint string, reqMessage, resMe
 	}
 
 	// Unmarshal response in the supplied resMessage instance
-	err = c.unmarshaler(resData, resMessage)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return c.unmarshaler(resData, resMessage)
 }

--- a/client/client.go
+++ b/client/client.go
@@ -14,10 +14,10 @@ import (
 //
 // The client uses a codec instance to marshal and unmarshal the request and
 // response objects accepted by the endpoint handlers into the low-level message
-// format used by the attached transport. Unless overriden by the WithCodec config
+// format used by the attached transport. Unless overridden by the WithCodec config
 // option, the client will invoke usrv.DefaultCodecFactory to fetch a codec instance.
 //
-// Unless overriden with the WithTransport config option, the client will invoke
+// Unless overridden with the WithTransport config option, the client will invoke
 // usrv.DefaultTransportFactory to fetch a transport instance.
 type Client struct {
 	// The transport used by the client.

--- a/client/middleware/circuitbreaker/circuitbreaker_test.go
+++ b/client/middleware/circuitbreaker/circuitbreaker_test.go
@@ -230,7 +230,7 @@ func TestCircuitBreakerWithEventChanWithoutListener(t *testing.T) {
 		TripThreshold:   2,
 		ResetThreshold:  3,
 		CoolOffPeriod:   500 * time.Millisecond,
-		StateChangeChan: make(chan State, 0),
+		StateChangeChan: make(chan State),
 	})
 
 	ctx := context.Background()

--- a/client/middleware/weightedrouting/weighted_routing.go
+++ b/client/middleware/weightedrouting/weighted_routing.go
@@ -64,7 +64,7 @@ type router struct {
 	// A RW mutex used for synchronizing access to the routing table.
 	mutex sync.RWMutex
 
-	// The list of versioned routes and their selection probabilites.
+	// The list of versioned routes and their selection probabilities.
 	routes []route
 
 	// A flag providing the weight configurations.

--- a/client/middleware/weightedrouting/weighted_routing.go
+++ b/client/middleware/weightedrouting/weighted_routing.go
@@ -79,7 +79,7 @@ type router struct {
 func newRouter(serviceName string) *router {
 	wr := &router{
 		weightCfg: flag.NewMap(cfgStore, "weighted_router/"+serviceName),
-		doneChan:  make(chan struct{}, 0),
+		doneChan:  make(chan struct{}),
 	}
 
 	// fetch initial weights

--- a/client/middleware/weightedrouting/weighted_routing_test.go
+++ b/client/middleware/weightedrouting/weighted_routing_test.go
@@ -138,7 +138,7 @@ func TestRouterLocks(t *testing.T) {
 	versionChan := make(chan string, len(randValues))
 	var wg sync.WaitGroup
 	wg.Add(len(randValues))
-	for _ = range randValues {
+	for range randValues {
 		go func() {
 			req := transport.MakeGenericMessage()
 			defer func() {
@@ -178,7 +178,7 @@ func TestRouterLocks(t *testing.T) {
 	randValues = []float32{0, 0.2999, 0.6999, 0.8, 0.2, 0.9, 0.9999}
 	wg.Add(len(randValues))
 
-	for _ = range randValues {
+	for range randValues {
 		go func() {
 			req := transport.MakeGenericMessage()
 			defer func() {

--- a/config/flag/flag.go
+++ b/config/flag/flag.go
@@ -29,7 +29,7 @@ type flagImpl struct {
 	// A channel for receiving notifications when the flag value changes.
 	changedChan chan struct{}
 
-	// A function for cancelling the watcher for this value.
+	// A function for canceling the watcher for this value.
 	unsubscribeFn store.UnsubscribeFunc
 
 	// A function for mapping incoming config events to a value that can be set.

--- a/config/flag/flag.go
+++ b/config/flag/flag.go
@@ -44,8 +44,8 @@ type cfgEventToValueMapper func(map[string]string) (interface{}, error)
 func (f *flagImpl) init(store *store.Store, valueMapper cfgEventToValueMapper, cfgPath string) {
 	f.store = store
 	f.valueMapper = valueMapper
-	f.changedChan = make(chan struct{}, 0)
-	f.hasValueChan = make(chan struct{}, 0)
+	f.changedChan = make(chan struct{})
+	f.hasValueChan = make(chan struct{})
 	f.version = -1
 	if f.checkEquality == nil {
 		f.checkEquality = func(v1, v2 interface{}) bool {

--- a/config/provider/envvars.go
+++ b/config/provider/envvars.go
@@ -44,7 +44,7 @@ func NewEnvVars() *EnvVars {
 //   "port/6379/tcp": "tcp://10.0.0.11:6379",
 //  }
 func (p *EnvVars) Get(path string) map[string]string {
-	cfg := make(map[string]string, 0)
+	cfg := make(map[string]string)
 
 	prefix := strings.Trim(strings.ToUpper(invalidCharRegex.ReplaceAllString(path, "_")), "_") + "_"
 	for _, envvar := range os.Environ() {

--- a/config/store/node.go
+++ b/config/store/node.go
@@ -108,7 +108,7 @@ func (n *node) leafValues(pathPrefix string, isRoot bool) map[string]string {
 
 	// Recursively build map by calling TreeValues on the child nodes and
 	// merging the maps into a single value map
-	valueMap := make(map[string]string, 0)
+	valueMap := make(map[string]string)
 	for _, subPathNode := range n.paths {
 		for k, v := range subPathNode.leafValues(pathPrefix, false) {
 			valueMap[k] = v
@@ -152,7 +152,7 @@ func (n *node) merge(version int, value interface{}) (modified bool) {
 		// Update the value and clear any existing child nodes
 		n.value, n.modified = mergeValue, true
 		if len(n.paths) != 0 {
-			n.paths = make(map[string]*node, 0)
+			n.paths = make(map[string]*node)
 		}
 
 		return true
@@ -224,7 +224,7 @@ func makeNode(segment string, depth int, parent *node) *node {
 	node := &node{
 		segment: segment,
 		depth:   depth,
-		paths:   make(map[string]*node, 0),
+		paths:   make(map[string]*node),
 		parent:  parent,
 	}
 

--- a/config/store/store.go
+++ b/config/store/store.go
@@ -209,7 +209,7 @@ func (s *Store) Get(path string) (map[string]string, int) {
 
 	root := s.lookup(path, false)
 	if root == nil {
-		return make(map[string]string, 0), -1
+		return make(map[string]string), -1
 	}
 
 	return root.leafValues("", true), root.version
@@ -269,7 +269,7 @@ func (s *Store) SetKey(version int, path, value string) (storeUpdated bool, err 
 // The method returns a boolean flag to indicate whether the store was updated
 // by any of the supplied values.
 func (s *Store) SetKeys(version int, path string, values map[string]string) (storeUpdated bool, err error) {
-	if values == nil || len(values) == 0 {
+	if len(values) == 0 {
 		return false, nil
 	}
 
@@ -306,7 +306,7 @@ func (s *Store) Watch(path string, changeHandler ChangeHandlerFunc) UnsubscribeF
 		numProviders = len(s.providers)
 	}
 	if s.watchers == nil {
-		s.watchers = make(map[string][]*changeWatcher, 0)
+		s.watchers = make(map[string][]*changeWatcher)
 	}
 
 	if s.watchers[path] == nil {
@@ -331,7 +331,7 @@ func (s *Store) Watch(path string, changeHandler ChangeHandlerFunc) UnsubscribeF
 		for index := len(s.providers) - 1; index >= 0; index-- {
 			provider := s.providers[index]
 			values := provider.instance.Get(path)
-			if values != nil && len(values) != 0 {
+			if len(values) != 0 {
 				valueTree, err := flattenedMapToTree(values)
 				if err == nil {
 					modFlag, pathRoot = s.set(index, path, valueTree)
@@ -582,7 +582,7 @@ nextSegment:
 //    }
 //  }
 func flattenedMapToTree(values map[string]string) (map[string]interface{}, error) {
-	root := make(map[string]interface{}, 0)
+	root := make(map[string]interface{})
 	var segmentMap *map[string]interface{}
 	for path, v := range values {
 		if len(path) == 0 {

--- a/config/store/store.go
+++ b/config/store/store.go
@@ -225,7 +225,7 @@ func (s *Store) Get(path string) (map[string]string, int) {
 // all of its children will be deleted and the node will be converted into a leaf.
 //
 // SetKey returns a boolean flag to indicate whether the store was updated. If
-// a version mismatch occured then SetKey will return false to indicate that no.
+// a version mismatch occurred then SetKey will return false to indicate that no.
 // update took place.
 func (s *Store) SetKey(version int, path, value string) (storeUpdated bool, err error) {
 	return s.setAndNotify(version, path, value), nil

--- a/config/store/store.go
+++ b/config/store/store.go
@@ -324,8 +324,7 @@ func (s *Store) Watch(path string, changeHandler ChangeHandlerFunc) UnsubscribeF
 	// apply it to the store; then register a watch for the same path. Provider
 	// values are applied in high to low priority order. This ensures the
 	// minimum number of nodes flagged as modified.
-	treeModified := false
-	modFlag := false
+	var treeModified, modFlag bool
 	var pathRoot *node
 	if numProviders > 0 {
 		for index := len(s.providers) - 1; index >= 0; index-- {

--- a/config/store/store_test.go
+++ b/config/store/store_test.go
@@ -365,7 +365,7 @@ func TestWatchersUnsubscribe(t *testing.T) {
 	// Calling unwatch on an unknown path while at least one watcher is defined should be ok
 	s.unwatch("/a/path", 1)()
 
-	// Unsubscribe should prevent further changes from beeing sent to the channel
+	// Unsubscribe should prevent further changes from being sent to the channel
 	unsubFn()
 
 	// Ensure that the watcher has been removed

--- a/encoding/gob/gob.go
+++ b/encoding/gob/gob.go
@@ -25,7 +25,7 @@ func (c *gobCodec) Unmarshaler() encoding.Unmarshaler {
 	}
 }
 
-// Codec retuns a codec that implements encoding and decoding of gob data.
+// Codec returns a codec that implements encoding and decoding of gob data.
 func Codec() encoding.Codec {
 	return &gobCodec{}
 }

--- a/encoding/json/json.go
+++ b/encoding/json/json.go
@@ -17,7 +17,7 @@ func (c *jsonCodec) Unmarshaler() encoding.Unmarshaler {
 	return json.Unmarshal
 }
 
-// Codec retuns a codec that implements encoding and decoding of JSON data.
+// Codec returns a codec that implements encoding and decoding of JSON data.
 func Codec() encoding.Codec {
 	return &jsonCodec{}
 }

--- a/encoding/msgpack/msgpack.go
+++ b/encoding/msgpack/msgpack.go
@@ -20,7 +20,7 @@ func (c *msgpackCodec) Unmarshaler() encoding.Unmarshaler {
 	}
 }
 
-// Codec retuns a codec that implements encoding and decoding of data using msgpack.
+// Codec returns a codec that implements encoding and decoding of data using msgpack.
 func Codec() encoding.Codec {
 	return &msgpackCodec{}
 }

--- a/encoding/protobuf/protobuf.go
+++ b/encoding/protobuf/protobuf.go
@@ -36,7 +36,7 @@ func (c *protobufCodec) Unmarshaler() encoding.Unmarshaler {
 	}
 }
 
-// Codec retuns a codec that implements encoding and decoding of protocol buffers.
+// Codec returns a codec that implements encoding and decoding of protocol buffers.
 func Codec() encoding.Codec {
 	return &protobufCodec{}
 }

--- a/server/middleware/concurrency/max_concurrent.go
+++ b/server/middleware/concurrency/max_concurrent.go
@@ -173,9 +173,9 @@ type resizableTokenPool struct {
 func newResizableTokenPool(maxTokens *flag.Int32) *resizableTokenPool {
 	pool := &resizableTokenPool{
 		maxTokens:   maxTokens,
-		doneChan:    make(chan struct{}, 0),
-		acquireChan: make(chan struct{}, 0),
-		releaseChan: make(chan struct{}, 0),
+		doneChan:    make(chan struct{}),
+		acquireChan: make(chan struct{}),
+		releaseChan: make(chan struct{}),
 	}
 	pool.spawnWorker()
 	setFinalizer(pool, func(p *resizableTokenPool) { p.Close() })

--- a/server/middleware/concurrency/max_concurrent_test.go
+++ b/server/middleware/concurrency/max_concurrent_test.go
@@ -73,7 +73,8 @@ func TestSingletonFactory(t *testing.T) {
 			MiddlewareFactories: append([]server.MiddlewareFactory{
 				func(next server.Middleware) server.Middleware {
 					return server.MiddlewareFunc(func(ctx context.Context, req transport.ImmutableMessage, res transport.Message) {
-						ctx, _ = context.WithTimeout(ctx, 50*time.Millisecond)
+						ctx, cancelFn := context.WithTimeout(ctx, 50*time.Millisecond)
+						defer cancelFn()
 						next.Handle(ctx, req, res)
 					})
 				},

--- a/server/middleware/concurrency/max_concurrent_test.go
+++ b/server/middleware/concurrency/max_concurrent_test.go
@@ -46,8 +46,8 @@ func TestSingletonFactory(t *testing.T) {
 	}
 	defer srv.Close()
 
-	workStartChan := make(chan struct{}, 0)
-	workDoneChan := make(chan struct{}, 0)
+	workStartChan := make(chan struct{})
+	workDoneChan := make(chan struct{})
 	err = srv.RegisterEndpoints(
 		&server.Endpoint{
 			Name: "ep1",
@@ -201,8 +201,8 @@ func TestFactory(t *testing.T) {
 	}
 	defer srv.Close()
 
-	workStartChan := make(chan struct{}, 0)
-	workDoneChan := make(chan struct{}, 0)
+	workStartChan := make(chan struct{})
+	workDoneChan := make(chan struct{})
 	err = srv.RegisterEndpoints(
 		&server.Endpoint{
 			Name: "ep1",
@@ -321,7 +321,7 @@ func TestSingletonFactoryWithDynamicConfiguration(t *testing.T) {
 	var wg sync.WaitGroup
 	wg.Add(2)
 
-	syncChan := make(chan struct{}, 0)
+	syncChan := make(chan struct{})
 	nextFn := server.MiddlewareFunc(func(_ context.Context, req transport.ImmutableMessage, res transport.Message) {
 		wg.Done()
 		<-syncChan

--- a/server/server.go
+++ b/server/server.go
@@ -143,7 +143,7 @@ func (s *Server) Listen() error {
 		return err
 	}
 
-	s.doneChan = make(chan struct{}, 0)
+	s.doneChan = make(chan struct{})
 	s.mutex.Unlock()
 
 	// Wait for a stop signal

--- a/server/server.go
+++ b/server/server.go
@@ -40,16 +40,16 @@ type PanicHandler func(error)
 //
 // The server uses a codec instance to marshal and unmarshal the request and
 // response objects accepted by the endpoint handlers into the low-level message
-// format used by the attached transport. Unless overriden by the WithCodec config
+// format used by the attached transport. Unless overridden by the WithCodec config
 // option, the server will invoke usrv.DefaultCodecFactory to fetch a codec instance.
 //
-// Unless overriden with the WithTransport config option, the server will invoke
+// Unless overridden with the WithTransport config option, the server will invoke
 // usrv.DefaultTransportFactory to fetch a transport instance.
 //
-// The server automatically recoveres and handling any panics while a request is
+// The server automatically recovers and handling any panics while a request is
 // being handled. A built-in panic handler implementation is used that simply
 // write the error and stack-trace to DefaultPanicWriter. However, the panic handler
-// can be overriden using the WithPanicHandler config option.
+// can be overridden using the WithPanicHandler config option.
 type Server struct {
 	// A mutext protecting access to the server fields.
 	mutex sync.Mutex

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -396,8 +396,7 @@ func TestServer(t *testing.T) {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		err := srv.Listen()
-		if err != nil {
+		if err = srv.Listen(); err != nil {
 			t.Fatal(err)
 		}
 	}()

--- a/transport/amqp/amqp.go
+++ b/transport/amqp/amqp.go
@@ -415,7 +415,7 @@ func (t *Transport) dialServer() error {
 }
 
 // redial is invoked whenever the amqp connection notifies us that an error
-// (usually EOF) has occured. This function will attempt to re-establish a
+// (usually EOF) has occurred. This function will attempt to re-establish a
 // connection and dial the client- and/or server-side of the transport.
 func (t *Transport) redial() error {
 	t.rwMutex.Lock()

--- a/transport/amqp/amqp.go
+++ b/transport/amqp/amqp.go
@@ -16,7 +16,6 @@ import (
 const (
 	replyCodeNotAuthorized uint16 = 403
 	replyCodeNotFound             = 404
-	replyCodeNoConsumers          = 313
 
 	contentTypeUsrvData = "application/usrv+data"
 	contentTypeError    = "application/usrv+error"

--- a/transport/amqp/amqp.go
+++ b/transport/amqp/amqp.go
@@ -62,7 +62,7 @@ var dialAndGetChan = func(amqpURI string) (amqpChannel, io.Closer, chan *amqpCli
 		return nil, nil, nil, err
 	}
 
-	connCloseChan := make(chan *amqpClient.Error, 0)
+	connCloseChan := make(chan *amqpClient.Error)
 	return amqpChan, amqpConn, amqpConn.NotifyClose(connCloseChan), nil
 }
 
@@ -207,7 +207,7 @@ type Transport struct {
 // New creates a new amqp transport instance.
 func New() *Transport {
 	return &Transport{
-		bindings: make(map[string]*binding, 0),
+		bindings: make(map[string]*binding),
 		amqpURI:  config.StringFlag("transport/amqp/uri"),
 	}
 }
@@ -248,7 +248,7 @@ func (t *Transport) dialAndVerifyExchange() error {
 		return err
 	}
 
-	t.monitorExitChan = make(chan struct{}, 0)
+	t.monitorExitChan = make(chan struct{})
 	go func(monitorExitChan chan struct{}) {
 		var err error
 		for {
@@ -336,11 +336,11 @@ func (t *Transport) dialClient() error {
 	t.amqpReplyQueueName = resQueue.Name
 
 	// Request to be notified about returned deliveries
-	t.failedDispatchChan = t.amqpChan.NotifyReturn(make(chan amqpClient.Return, 0))
+	t.failedDispatchChan = t.amqpChan.NotifyReturn(make(chan amqpClient.Return))
 
 	// Start the client worker and wait for it to ack that its up & running
-	t.outgoingReqChan = make(chan *rpc, 0)
-	t.clientExitChan = make(chan struct{}, 0)
+	t.outgoingReqChan = make(chan *rpc)
+	t.clientExitChan = make(chan struct{})
 	<-t.spawnClientWorker()
 
 	t.clientRefCount++
@@ -615,7 +615,7 @@ func (t *Transport) Request(msg transport.Message) <-chan transport.ImmutableMes
 // or the channel closes. This function returns a channel which is closed when
 // the worker go-routine has started.
 func (t *Transport) spawnServerWorker() chan struct{} {
-	serverStartedChan := make(chan struct{}, 0)
+	serverStartedChan := make(chan struct{})
 
 	// Keep local copies of the channels we need. This prevents data-race
 	// warnings when running tests that involve redialing the transport
@@ -707,7 +707,7 @@ func (t *Transport) spawnServerWorker() chan struct{} {
 //
 // This function returns a channel which is closed when the worker go-routine has started.
 func (t *Transport) spawnClientWorker() chan struct{} {
-	clientStartedChan := make(chan struct{}, 0)
+	clientStartedChan := make(chan struct{})
 
 	// Keep local copies of the channels we need. This prevents data-race
 	// warnings when running tests that involve redialing the transport
@@ -717,7 +717,7 @@ func (t *Transport) spawnClientWorker() chan struct{} {
 	clientExitChan := t.clientExitChan
 
 	go func() {
-		pendingClientRequests := make(map[string]*rpc, 0)
+		pendingClientRequests := make(map[string]*rpc)
 
 		defer func() {
 			// Abort pending client requests with ErrServiceUnavailable

--- a/transport/amqp/amqp_test.go
+++ b/transport/amqp/amqp_test.go
@@ -140,7 +140,7 @@ func TestServerDisconnectHandling(t *testing.T) {
 	}()
 
 	mc := &mockChannel{
-		consumeChan: make(chan amqpClient.Delivery, 0),
+		consumeChan: make(chan amqpClient.Delivery),
 	}
 	dialAndGetChan = func(_ string) (amqpChannel, io.Closer, chan *amqpClient.Error, error) {
 		return mc, mc, nil, nil
@@ -210,7 +210,7 @@ func TestRequestForInvalidBinding(t *testing.T) {
 	}()
 
 	mc := &mockChannel{
-		consumeChan: make(chan amqpClient.Delivery, 0),
+		consumeChan: make(chan amqpClient.Delivery),
 		pubQueue:    make(chan amqpClient.Publishing, 1),
 	}
 	dialAndGetChan = func(_ string) (amqpChannel, io.Closer, chan *amqpClient.Error, error) {
@@ -260,7 +260,7 @@ func TestRequestForValidBinding(t *testing.T) {
 	}()
 
 	mc := &mockChannel{
-		consumeChan: make(chan amqpClient.Delivery, 0),
+		consumeChan: make(chan amqpClient.Delivery),
 		pubQueue:    make(chan amqpClient.Publishing, 1),
 	}
 	dialAndGetChan = func(_ string) (amqpChannel, io.Closer, chan *amqpClient.Error, error) {
@@ -285,7 +285,7 @@ func TestRequestForValidBinding(t *testing.T) {
 	}
 
 	// Define binding
-	invokedChan := make(chan struct{}, 0)
+	invokedChan := make(chan struct{})
 	expPayload := []byte("response data")
 	err = tr.Bind("", "service", "remote-endpoint", transport.HandlerFunc(func(reqMsg transport.ImmutableMessage, res transport.Message) {
 		if reqMsg.ID() != req.ID() {
@@ -365,7 +365,7 @@ func TestRequestForValidBindingWhenPublishFails(t *testing.T) {
 	}()
 
 	mc := &mockChannel{
-		consumeChan: make(chan amqpClient.Delivery, 0),
+		consumeChan: make(chan amqpClient.Delivery),
 		pubQueue:    make(chan amqpClient.Publishing, 1),
 	}
 	dialAndGetChan = func(_ string) (amqpChannel, io.Closer, chan *amqpClient.Error, error) {
@@ -386,7 +386,7 @@ func TestRequestForValidBindingWhenPublishFails(t *testing.T) {
 	req.ReceiverEndpointField = "remote-endpoint"
 
 	// Define binding
-	invokedChan := make(chan struct{}, 0)
+	invokedChan := make(chan struct{})
 	err = tr.Bind("", "service", "remote-endpoint", transport.HandlerFunc(func(reqMsg transport.ImmutableMessage, res transport.Message) {
 		close(invokedChan)
 	}))
@@ -433,8 +433,8 @@ func TestClientWorkerHandlingOfClosedAmqpChannels(t *testing.T) {
 	}()
 
 	mc := &mockChannel{
-		consumeChan: make(chan amqpClient.Delivery, 0),
-		returnChan:  make(chan amqpClient.Return, 0),
+		consumeChan: make(chan amqpClient.Delivery),
+		returnChan:  make(chan amqpClient.Return),
 		pubQueue:    make(chan amqpClient.Publishing, 2),
 	}
 	dialAndGetChan = func(_ string) (amqpChannel, io.Closer, chan *amqpClient.Error, error) {
@@ -450,7 +450,7 @@ func TestClientWorkerHandlingOfClosedAmqpChannels(t *testing.T) {
 	// queue rpc message and then close the response channel
 	rpcReq := &rpc{
 		req:     transport.MakeGenericMessage(),
-		resChan: make(chan transport.ImmutableMessage, 0),
+		resChan: make(chan transport.ImmutableMessage),
 	}
 	tr.outgoingReqChan <- rpcReq
 
@@ -473,7 +473,7 @@ func TestClientWorkerHandlingOfClosedAmqpChannels(t *testing.T) {
 	// queue rpc message and then close the return channel
 	rpcReq = &rpc{
 		req:     transport.MakeGenericMessage(),
-		resChan: make(chan transport.ImmutableMessage, 0),
+		resChan: make(chan transport.ImmutableMessage),
 	}
 	tr.outgoingReqChan <- rpcReq
 
@@ -595,7 +595,7 @@ func TestClientWorkerWhenReceivingResponses(t *testing.T) {
 	}()
 
 	mc := &mockChannel{
-		consumeChan: make(chan amqpClient.Delivery, 0),
+		consumeChan: make(chan amqpClient.Delivery),
 		pubQueue:    make(chan amqpClient.Publishing, 1),
 	}
 	dialAndGetChan = func(_ string) (amqpChannel, io.Closer, chan *amqpClient.Error, error) {
@@ -680,7 +680,7 @@ func TestClientWorkerWhenReceivingResponsesWithBogusID(t *testing.T) {
 	}()
 
 	mc := &mockChannel{
-		consumeChan: make(chan amqpClient.Delivery, 0),
+		consumeChan: make(chan amqpClient.Delivery),
 		pubQueue:    make(chan amqpClient.Publishing, 1),
 	}
 	dialAndGetChan = func(_ string) (amqpChannel, io.Closer, chan *amqpClient.Error, error) {
@@ -1392,7 +1392,7 @@ type amqpProxy struct {
 }
 
 func (p *amqpProxy) connWorker(realAmqpHost string) {
-	p.killConnChan = make(chan struct{}, 0)
+	p.killConnChan = make(chan struct{})
 
 	for {
 		srcConn, err := p.proxyListener.Accept()

--- a/transport/amqp/amqp_test.go
+++ b/transport/amqp/amqp_test.go
@@ -352,6 +352,8 @@ func TestRequestForValidBinding(t *testing.T) {
 		t.Errorf("expected response appID and userID to be %q, %q; got %q, %q", req.Receiver(), req.ReceiverEndpoint(), pub.AppId, pub.Type)
 	}
 
+	// Allow some time for the handler to ack the request
+	<-time.After(100 * time.Millisecond)
 	expAckCount := 1
 	if mc.AckCount() != expAckCount {
 		t.Errorf("expected ack count to be %d; got %d", expAckCount, mc.AckCount())

--- a/transport/amqp/amqp_test.go
+++ b/transport/amqp/amqp_test.go
@@ -750,7 +750,6 @@ func TestClientWorkerReturnHandling(t *testing.T) {
 	}{
 		{replyCodeNotFound, transport.ErrNotFound},
 		{replyCodeNotAuthorized, transport.ErrNotAuthorized},
-		{replyCodeNoConsumers, transport.ErrServiceUnavailable},
 		{500, transport.ErrServiceUnavailable},
 	}
 

--- a/transport/http/http.go
+++ b/transport/http/http.go
@@ -212,7 +212,7 @@ type Transport struct {
 	client    requestMaker
 	clientErr error
 
-	// URLBuilder can be overriden to implement custom service discovery rules.
+	// URLBuilder can be overridden to implement custom service discovery rules.
 	URLBuilder ServiceURLBuilder
 }
 
@@ -377,7 +377,7 @@ func (t *Transport) Request(reqMsg transport.Message) <-chan transport.Immutable
 		}
 
 		// Always append internal headers after any user-defined headers
-		// so that they cannot be accidentally overriden
+		// so that they cannot be accidentally overridden
 		httpReq.Header.Set(headerPrefix+requestIDHeader, reqMsg.ID())
 		httpReq.Header.Set(headerPrefix+senderHeader, reqMsg.Sender())
 		httpReq.Header.Set(headerPrefix+senderEndpointHeader, reqMsg.SenderEndpoint())

--- a/transport/http/http.go
+++ b/transport/http/http.go
@@ -219,7 +219,7 @@ type Transport struct {
 // New creates a new http transport instance.
 func New() *Transport {
 	t := &Transport{
-		bindings:      make(map[string]*binding, 0),
+		bindings:      make(map[string]*binding),
 		config:        config.MapFlag("transport/http"),
 		protocol:      config.StringFlag("transport/http/protocol"),
 		port:          config.Uint32Flag("transport/http/port"),
@@ -228,7 +228,7 @@ func New() *Transport {
 		tlsVerify:     config.StringFlag("transport/http/client/verifycert"),
 		tlsStrictMode: config.BoolFlag("transport/http/tls/strict"),
 
-		watcherDoneChan: make(chan struct{}, 0),
+		watcherDoneChan: make(chan struct{}),
 	}
 
 	go t.configChangeMonitor()
@@ -492,13 +492,13 @@ func (t *Transport) dial() error {
 	// Start server goroutine
 	var wg sync.WaitGroup
 	wg.Add(1)
-	t.serverDoneChan = make(chan struct{}, 0)
+	t.serverDoneChan = make(chan struct{})
 	go func(doneChan chan struct{}) {
 		wg.Done()
 		srv := nethttp.Server{
 			Handler:      nethttp.HandlerFunc(t.mux(t.tlsStrictMode.Get())),
 			TLSConfig:    tlsConfig,
-			TLSNextProto: make(map[string]func(*nethttp.Server, *tls.Conn, nethttp.Handler), 0),
+			TLSNextProto: make(map[string]func(*nethttp.Server, *tls.Conn, nethttp.Handler)),
 		}
 		srv.Serve(t.listener)
 		close(doneChan)

--- a/transport/http/http_test.go
+++ b/transport/http/http_test.go
@@ -440,7 +440,7 @@ func TestRPCOverHTTP(t *testing.T) {
 			t.Errorf("header mismatch; expected %v; got %v", expHeaders, headers)
 		}
 
-		// Populate respone
+		// Populate response
 		res.SetPayload([]byte("hello back!"), nil)
 
 		// Add extra user header

--- a/transport/http/http_test.go
+++ b/transport/http/http_test.go
@@ -99,7 +99,7 @@ func TestHTTPClientErrors(t *testing.T) {
 
 	// Request when transport is closed
 	res := <-tr.Request(newMessage("test/producer", "service/endpoint"))
-	if _, err := res.Payload(); err != transport.ErrTransportClosed {
+	if _, err = res.Payload(); err != transport.ErrTransportClosed {
 		t.Fatalf("expected to get error %q; got %v", transport.ErrTransportClosed, err)
 	}
 	res.Close()
@@ -124,7 +124,7 @@ func TestHTTPClientErrors(t *testing.T) {
 	}
 	res = <-tr.Request(newMessage("test/producer", "service/endpoint"))
 	newRequest = origNewRequest
-	if _, err := res.Payload(); err == nil || err.Error() != expError {
+	if _, err = res.Payload(); err == nil || err.Error() != expError {
 		t.Fatalf("expected to get error %q; got %v", expError, err)
 	}
 	res.Close()
@@ -137,7 +137,7 @@ func TestHTTPClientErrors(t *testing.T) {
 	}
 	res = <-tr.Request(newMessage("test/producer", "service/endpoint"))
 	readAll = origReadAll
-	if _, err := res.Payload(); err == nil || err.Error() != expError {
+	if _, err = res.Payload(); err == nil || err.Error() != expError {
 		t.Fatalf("expected to get error %q; got %v", expError, err)
 	}
 

--- a/transport/memory/in_memory.go
+++ b/transport/memory/in_memory.go
@@ -25,7 +25,7 @@ type Transport struct {
 // New creates a new in-memory transport instance.
 func New() *Transport {
 	return &Transport{
-		bindings: make(map[string]transport.Handler, 0),
+		bindings: make(map[string]transport.Handler),
 	}
 }
 

--- a/transport/memory/in_memory_test.go
+++ b/transport/memory/in_memory_test.go
@@ -164,7 +164,7 @@ func TestInMemoryRPC(t *testing.T) {
 			t.Errorf("header mismatch; expected %v; got %v", expHeaders, headers)
 		}
 
-		// Populate respone
+		// Populate response
 		res.SetPayload([]byte("hello back!"), nil)
 	}
 
@@ -218,7 +218,7 @@ func TestInMemoryRPC(t *testing.T) {
 		t.Errorf("expected payload to be %q; got %q", expValues[0], string(payload))
 	}
 
-	// Try a request with a specific service verison request
+	// Try a request with a specific service version request
 	req.SetReceiverVersion("v0")
 	resChan = tr.Request(req)
 	res = <-resChan

--- a/transport/memory/in_memory_test.go
+++ b/transport/memory/in_memory_test.go
@@ -66,7 +66,7 @@ func TestInMemoryErrors(t *testing.T) {
 	// Send to unknown endpoint
 	resChan := tr.Request(newMessage("test/case", "unknown/endpoint"))
 	res := <-resChan
-	if _, err := res.Payload(); err != transport.ErrNotFound {
+	if _, err = res.Payload(); err != transport.ErrNotFound {
 		t.Fatalf("expected err %v; got %v", transport.ErrNotFound, err)
 	}
 

--- a/transport/memory/in_memory_test.go
+++ b/transport/memory/in_memory_test.go
@@ -15,9 +15,8 @@ func TestInMemoryBindVersions(t *testing.T) {
 	defer tr.Close(transport.ModeServer)
 
 	handler := transport.HandlerFunc(func(_ transport.ImmutableMessage, _ transport.Message) {})
-	var err error
 
-	err = tr.Bind("v0", "service", "endpoint", handler)
+	err := tr.Bind("v0", "service", "endpoint", handler)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -268,7 +267,7 @@ func benchInMemory(b *testing.B, workers int) {
 	payload := []byte("test payload")
 	msgPerWorker := (b.N / workers) + 1
 
-	start := make(chan struct{}, 0)
+	start := make(chan struct{})
 	var wgStart, wgEnd sync.WaitGroup
 	wgStart.Add(workers)
 	wgEnd.Add(workers * msgPerWorker)

--- a/transport/message_impl.go
+++ b/transport/message_impl.go
@@ -113,7 +113,7 @@ func (m *GenericMessage) SetPayload(payload []byte, err error) {
 func MakeGenericMessage() *GenericMessage {
 	m := msgPool.Get().(*GenericMessage)
 	m.IDField = GenerateID()
-	m.HeadersField = make(map[string]string, 0)
+	m.HeadersField = make(map[string]string)
 	m.PayloadField = nil
 	m.ErrField = nil
 	m.ReceiverVersionField = ""


### PR DESCRIPTION
This PR fixes warnings emitted by the following linters:
- errcheck
- vet
- vet_shadow
- misspell
- gosimple
- ineffassign

Running the gocyclo linter `gometalinter --deadline=30s --disable-all --enable=gocyclo --cyclo-over=15` using the same configuration as goscorecard still complains about cyclomatic complexity but that's mostly in the test code.